### PR TITLE
Fix issues with admin base view

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,8 @@ keywords =
 include_package_data = True
 packages = find:
 install_requires =
-    shuup
+    shuup<2
+    dictdiffer<1
 
 [options.entry_points]
 shuup.addon = shuup_logging = shuup_logging

--- a/shuup_logging/views.py
+++ b/shuup_logging/views.py
@@ -7,6 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 
+from dictdiffer import diff
 from django.utils.translation import ugettext_lazy as _
 from shuup.admin.utils.picotable import (
     ChoicesFilter, Column, DateRangeFilter, TextFilter
@@ -20,6 +21,7 @@ class BaseLogListView(PicotableListView):
     model = None
     user_search_field = "user__username"
     target_search_field = None  # Define in parent class
+    hide_extra = False
 
     default_columns = [
         Column(
@@ -52,7 +54,11 @@ class BaseLogListView(PicotableListView):
 
     def __init__(self):
         super(BaseLogListView, self).__init__()
-        self.columns = self.default_columns
+        if self.hide_extra:
+            self.columns = [column for column in self.default_columns if column.id != "extra"]
+        else:
+            self.columns = self.default_columns
+
 
     def format_user(self, instance, *args, **kwargs):
         if instance.user:
@@ -64,16 +70,22 @@ class BaseLogListView(PicotableListView):
             try:
                 return '<a href=%s target="_blank">%s</a>' % (get_model_url(instance.target), instance.target)
             except Exception as e:
-                return instance.target
+                return instance.target.pk
         return "-"
 
     def get_extra_change(self, instance, *args, **kwargs):
+        if not instance.extra:
+            return "-"
+
         previous_item = self.model.objects.filter(
             pk__lt=instance.pk, identifier=instance.identifier
         ).order_by("id").first()
-        if previous_item:
-            diff = set(instance.extra.items()) - set(previous_item.extra.items())
-            return str({k: value for k, value in diff})
+        if previous_item and previous_item.extra:
+            changes = []
+            for action, attr, value_change in diff(instance.extra, previous_item.extra):
+                changes.append(
+                    "%s %s from [%s] to [%s]." % (action.capitalize(), attr, value_change[1], value_change[0]))
+            return " | ".join(changes)
         return "-"
 
     def get_queryset(self):


### PR DESCRIPTION
Fallback to target pk when URL can not be derived. This avoids
serialization issues with the target.

Do not expect that each logged items has extra-data.