### PR TITLE
Fix error with 2 menu options shown bold

### DIFF
--- a/shuup_logging/admin/__init__.py
+++ b/shuup_logging/admin/__init__.py
@@ -28,7 +28,6 @@ MENU_ENTRIES_URL_NAME_TO_TITLE = {
 
 class LogsModule(AdminModule):
     name = _("Logs")
-    breadcrumbs_menu_entry = MenuEntry(name, url="shuup_admin:shuup_logging.product_log")
 
     def get_urls(self):
         from shuup.admin.urls import admin_url


### PR DESCRIPTION
In `Admin Panel/Logs` menu, `Product Logs` sub-menu was always in bold 
font style, regardless of which sub-menu option was actually chosen and 
active.

Picture of a bug:
![image](https://user-images.githubusercontent.com/2521942/70435589-e69e4900-1a8f-11ea-9ab0-ef00046dd53e.png)
