### PR TITLE
Improve descriptions, help texts, error messages, etc

### DIFF
--- a/shuup_logging/signal_handlers.py
+++ b/shuup_logging/signal_handlers.py
@@ -19,7 +19,7 @@ def product_post_save(sender, object, request, **kwargs):
     if isinstance(object, Product):
         # TODO: check if extra has changed from last log entry
         object.add_log_entry(
-            "Product saved at admin",
+            "Success! Product saved at admin.",
             user=request.user,
             identifier=SHUUP_LOGGING_ADMIN_SAVE_LOG_IDENTIFIER,
             kind=LogEntryKind.EDIT,
@@ -32,7 +32,7 @@ def shop_product_post_save(sender, object, request, **kwargs):
     if isinstance(object, ShopProduct):
         # TODO: check if extra has changed from last log entry
         object.add_log_entry(
-            "Shop product saved at admin",
+            "Success! Shop product saved at admin.",
             user=request.user,
             identifier=SHUUP_LOGGING_ADMIN_SAVE_LOG_IDENTIFIER,
             kind=LogEntryKind.EDIT,
@@ -45,7 +45,7 @@ def supplier_post_save(sender, object, request, **kwargs):
     if isinstance(object, Supplier):
         # TODO: check if extra has changed from last log entry
         object.add_log_entry(
-            "Supplier saved at admin",
+            "Success! Supplier saved at admin.",
             user=request.user,
             identifier=SHUUP_LOGGING_ADMIN_SAVE_LOG_IDENTIFIER,
             kind=LogEntryKind.EDIT,


### PR DESCRIPTION
This is part of a big update to improve various texts in Shuup.

A lot of changes, touching almost every individual Shuup project's repo.

There are too many changes to try to describe them separately, but the 
main ones are:
1. Improve `help_text` descriptions. Fix typos, rewrite and change, 
write new ones.
2. Change some of the model field names (for example rename 
`available_from` -> `available_since`; `available_to` `available_until` 
- this is in a separate commit).
3. Improve some of the documentation.
4. Improve some in-code-comments.
5. Improve `settings.py` files. It's now clearer what each option does.
6. Change some of the naming.
7. Change the error/message system.

The main Shuup repo's Merge Request is here: 
https://github.com/shuup/shuup/pull/2113 (with a reasoning behind 
changes).